### PR TITLE
Work in progress: Use xi-unicode for line breaking

### DIFF
--- a/components/gfx/Cargo.toml
+++ b/components/gfx/Cargo.toml
@@ -44,6 +44,7 @@ azure = {git = "https://github.com/servo/rust-azure", features = ["plugins"]}
 layers = {git = "https://github.com/servo/rust-layers", features = ["plugins"]}
 ipc-channel = {git = "https://github.com/servo/ipc-channel"}
 webrender_traits = {git = "https://github.com/servo/webrender_traits"}
+xi-unicode = "0.0.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.2"

--- a/components/gfx/lib.rs
+++ b/components/gfx/lib.rs
@@ -80,6 +80,7 @@ extern crate unicode_script;
 extern crate url;
 extern crate util;
 extern crate webrender_traits;
+extern crate xi_unicode;
 
 pub use paint_context::PaintContext;
 

--- a/components/gfx/text/text_run.rs
+++ b/components/gfx/text/text_run.rs
@@ -12,7 +12,9 @@ use std::cmp::{Ordering, max};
 use std::slice::Iter;
 use std::sync::Arc;
 use text::glyph::{ByteIndex, GlyphStore};
+use util::str::char_is_whitespace;
 use webrender_traits;
+use xi_unicode::LineBreakIterator;
 
 thread_local! {
     static INDEX_OF_FIRST_GLYPH_RUN_CACHE: Cell<Option<(*const TextRun, ByteIndex, usize)>> =
@@ -191,73 +193,40 @@ impl<'a> TextRun {
 
     pub fn break_and_shape(font: &mut Font, text: &str, options: &ShapingOptions)
                            -> Vec<GlyphRun> {
-        // TODO(Issue #230): do a better job. See Gecko's LineBreaker.
         let mut glyphs = vec!();
-        let mut byte_i = 0;
-        let mut cur_slice_is_whitespace = false;
-        let mut byte_last_boundary = 0;
+        let mut slice = 0..0;
 
-        for ch in text.chars() {
-            // Slices alternate between whitespace and non-whitespace,
-            // representing line break opportunities.
-            let can_break_before = if cur_slice_is_whitespace {
-                match ch {
-                    ' ' | '\t' | '\n' => false,
-                    _ => {
-                        cur_slice_is_whitespace = false;
-                        true
-                    }
-                }
-            } else {
-                match ch {
-                    ' ' | '\t' | '\n' => {
-                        cur_slice_is_whitespace = true;
-                        true
-                    },
-                    _ => false
-                }
-            };
+        for (idx, _is_hard_break) in LineBreakIterator::new(text) {
+            // Extend the slice to the next UAX#14 line break opportunity.
+            slice.end = idx;
+            let word = &text[slice.clone()];
 
-            // Create a glyph store for this slice if it's nonempty.
-            if can_break_before && byte_i > byte_last_boundary {
-                let slice = &text[byte_last_boundary .. byte_i];
-                debug!("creating glyph store for slice {} (ws? {}), {} - {} in run {}",
-                        slice, !cur_slice_is_whitespace, byte_last_boundary, byte_i, text);
+            // Split off any trailing whitespace into a separate glyph run.
+            let mut whitespace = slice.end..slice.end;
+            if let Some((i,_)) = word.char_indices().rev()
+                                     .take_while(|&(_, c)| char_is_whitespace(c)).last() {
+                whitespace.start = slice.start + i;
+                slice.end = whitespace.start;
+            }
 
-                let mut options = *options;
-                if !cur_slice_is_whitespace {
-                    options.flags.insert(IS_WHITESPACE_SHAPING_FLAG);
-                }
-
+            if slice.len() > 0 {
                 glyphs.push(GlyphRun {
-                    glyph_store: font.shape_text(slice, &options),
-                    range: Range::new(ByteIndex(byte_last_boundary as isize),
-                                      ByteIndex((byte_i - byte_last_boundary) as isize)),
+                    glyph_store: font.shape_text(&text[slice.clone()], options),
+                    range: Range::new(ByteIndex(slice.start as isize),
+                                      ByteIndex(slice.len() as isize)),
                 });
-                byte_last_boundary = byte_i;
             }
-
-            byte_i = byte_i + ch.len_utf8();
-        }
-
-        // Create a glyph store for the final slice if it's nonempty.
-        if byte_i > byte_last_boundary {
-            let slice = &text[byte_last_boundary..];
-            debug!("creating glyph store for final slice {} (ws? {}), {} - {} in run {}",
-                slice, cur_slice_is_whitespace, byte_last_boundary, text.len(), text);
-
-            let mut options = *options;
-            if cur_slice_is_whitespace {
+            if whitespace.len() > 0 {
+                let mut options = options.clone();
                 options.flags.insert(IS_WHITESPACE_SHAPING_FLAG);
+                glyphs.push(GlyphRun {
+                    glyph_store: font.shape_text(&text[whitespace.clone()], &options),
+                    range: Range::new(ByteIndex(whitespace.start as isize),
+                                      ByteIndex(whitespace.len() as isize)),
+                });
             }
-
-            glyphs.push(GlyphRun {
-                glyph_store: font.shape_text(slice, &options),
-                range: Range::new(ByteIndex(byte_last_boundary as isize),
-                                  ByteIndex((byte_i - byte_last_boundary) as isize)),
-            });
+            slice.start = whitespace.end;
         }
-
         glyphs
     }
 

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -735,6 +735,7 @@ dependencies = [
  "url 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
  "webrender_traits 0.1.0 (git+https://github.com/servo/webrender_traits)",
+ "xi-unicode 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2503,6 +2504,11 @@ dependencies = [
  "dylib 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "xi-unicode"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "xml-rs"

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -664,6 +664,7 @@ dependencies = [
  "url 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
  "webrender_traits 0.1.0 (git+https://github.com/servo/webrender_traits)",
+ "xi-unicode 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2369,6 +2370,11 @@ dependencies = [
  "dylib 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "xi-unicode"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "xml-rs"

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -667,6 +667,7 @@ dependencies = [
  "url 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
  "webrender_traits 0.1.0 (git+https://github.com/servo/webrender_traits)",
+ "xi-unicode 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2320,6 +2321,11 @@ dependencies = [
  "dylib 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "xi-unicode"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "xml-rs"


### PR DESCRIPTION
This uses the xi-unicode crate to detect line-break opportunities, replacing Servo's custom code that only detects ASCII whitespace.  It is built on top of servo/servo#10895.

There is one regression: Servo currently splits text into a sequence of slices that alternate all-non-whitespace with all-whitespace.  This makes it easy for the line breaking code to ignore the width of trailing whitespace.  But xi_unicode::LineBreakIterator only "breaks" the text at the end of each whitespace run, not at its start.  This PR splits text only on these breaks, so each "word" may include trailing whitespace, causing Servo to sometimes break lines earlier than necessary. @raphlinus, would it make sense to extend xi_unicode to (optionally) find whitespace ranges? Or do you have any other suggestions?

@raphlinus, it would also be nice if xi-unicode were published on crates.io so that we can depend on that instead of the xi-editor repo.

cc @pcwalton
